### PR TITLE
key iterator returns done if fetch retrieved no keys

### DIFF
--- a/record.go
+++ b/record.go
@@ -225,6 +225,10 @@ func (it *KeyIterator) Next() (*Key, error) {
 		if it.token == "" {
 			it.end = true
 		}
+
+		if len(it.keys) == 0 {
+			return nil, ErrDone
+		}
 	}
 
 	k := it.keys[0]


### PR DESCRIPTION
This changes fixed an index out of range error that occurs when performing a key fetch that returns no keys because there are no records in the collection.