### PR TITLE
parse duration in query results if not nil

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -128,9 +128,13 @@ func processResponse(pbResp *pipelinepb.QueryResults, tokens ...*pipelinepb.Toke
 		results = append(results, r)
 	}
 
-	d, err := ptypes.Duration(pbResp.GetLatency())
-	if err != nil {
-		return nil, err
+	var d time.Duration
+	var err error
+	if pbResp.GetLatency() != nil {
+		d, err = ptypes.Duration(pbResp.GetLatency())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	resp := &Results{

--- a/pipeline.go
+++ b/pipeline.go
@@ -134,12 +134,12 @@ func processResponse(pbResp *pipelinepb.QueryResults, tokens ...*pipelinepb.Toke
 		Results:      results,
 	}
 
-	if pbResp.GetLatency() != nil {
-		d, err := ptypes.Duration(pbResp.GetLatency())
+	if pbL := pbResp.GetLatency(); pbL != nil {
+		l, err := ptypes.Duration(pbL)
 		if err != nil {
 			return nil, err
 		}
-		resp.Latency = d
+		resp.Latency = l
 	}
 
 	if pbA := pbResp.GetAggregates(); pbA != nil {

--- a/pipeline.go
+++ b/pipeline.go
@@ -128,20 +128,18 @@ func processResponse(pbResp *pipelinepb.QueryResults, tokens ...*pipelinepb.Toke
 		results = append(results, r)
 	}
 
-	var d time.Duration
-	var err error
-	if pbResp.GetLatency() != nil {
-		d, err = ptypes.Duration(pbResp.GetLatency())
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	resp := &Results{
 		Reads:        int(pbResp.GetReads()),
 		TotalResults: int(pbResp.GetTotalResults()),
-		Latency:      d,
 		Results:      results,
+	}
+
+	if pbResp.GetLatency() != nil {
+		d, err := ptypes.Duration(pbResp.GetLatency())
+		if err != nil {
+			return nil, err
+		}
+		resp.Latency = d
 	}
 
 	if pbA := pbResp.GetAggregates(); pbA != nil {


### PR DESCRIPTION
The duration is the time for the engine to perform the query request. However pipeline may not necessarily perform a engine query request and in this scenario the duration is nil.