### PR TITLE
record: return error wrapping ErrNoSuchRecord when deleting

### DIFF
--- a/record.go
+++ b/record.go
@@ -182,7 +182,12 @@ func (c *Client) DeleteRecord(ctx context.Context, k *Key) error {
 		Key: pbk,
 	})
 	if err != nil {
-		return fmt.Errorf("could not delete record: %w", err)
+		switch code := status.Code(err); code {
+		case codes.NotFound:
+			return fmt.Errorf("%v: %w", k, ErrNoSuchRecord)
+		default:
+			return fmt.Errorf("could not delete record: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
The method doc was previously updated to say that the method would
return an error wrapping ErrNoSuchRecord, but the implementation was
never updated to do so.