### PR TITLE
run codegen to fix incorrect error response types

### DIFF
--- a/internal/openapi/api/openapi.yaml
+++ b/internal/openapi/api/openapi.yaml
@@ -12,10 +12,10 @@ info:
   version: v4
   x-logo:
     altText: Sajari
-    url: /docs/api-reference/logo-full.png
+    url: https://cdn.sajari.net/v2/img/logo-full.svg
 externalDocs:
   description: Read more about the Sajari API
-  url: https://www.sajari.com/docs
+  url: https://docs.sajari.com
 servers:
 - url: https://api-gateway.sajari.com
 security:
@@ -127,12 +127,12 @@ paths:
         style: form
       - description: |-
           A page token, received from a previous
-          [ListCollections](/docs/api-reference#operation/ListCollections) call.
+          [ListCollections](/api#operation/ListCollections) call.
 
           Provide this to retrieve the subsequent page.
 
           When paginating, all other parameters provided to
-          [ListCollections](/docs/api-reference#operation/ListCollections) must match
+          [ListCollections](/api#operation/ListCollections) must match
           the call that provided the page token.
         explode: true
         in: query
@@ -151,24 +151,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -230,25 +234,28 @@ paths:
                       - field: collection_id
                         description: collection_id cannot be empty
               schema:
-                $ref: '#/components/schemas/Status'
+                $ref: '#/components/schemas/Error'
           description: Returned when the request contains violations for one or more
             fields.
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "409":
           content:
@@ -259,12 +266,13 @@ paths:
                     code: 6
                     message: resource already exists
               schema:
-                $ref: '#/components/schemas/Status'
+                $ref: '#/components/schemas/Error'
           description: Returned when the collection already exists.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -301,13 +309,15 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
@@ -319,12 +329,13 @@ paths:
                     code: 5
                     message: resource not found
               schema:
-                $ref: '#/components/schemas/Status'
+                $ref: '#/components/schemas/Error'
           description: Returned when the collection was not found.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -357,24 +368,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -429,13 +444,15 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
@@ -447,12 +464,13 @@ paths:
                     code: 5
                     message: resource not found
               schema:
-                $ref: '#/components/schemas/Status'
+                $ref: '#/components/schemas/Error'
           description: Returned when the collection was not found.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -493,12 +511,12 @@ paths:
         style: form
       - description: |-
           A page token, received from a previous
-          [ListPipelines](/docs/api-reference#operation/ListPipelines) call.
+          [ListPipelines](/api#operation/ListPipelines) call.
 
           Provide this to retrieve the subsequent page.
 
           When paginating, all other parameters provided to
-          [ListPipelines](/docs/api-reference#operation/ListPipelines) must match the
+          [ListPipelines](/api#operation/ListPipelines) must match the
           call that provided the page token.
         explode: true
         in: query
@@ -514,8 +532,8 @@ paths:
           The API defaults to the `BASIC` view.
            - BASIC: Include basic information including type, name, version and description
           but not the full step configuration. This is the default value (for both
-          [ListPipelines](/docs/api-reference#operation/ListPipelines) and
-          [GetPipeline](/docs/api-reference#operation/GetPipeline)).
+          [ListPipelines](/api#operation/ListPipelines) and
+          [GetPipeline](/api#operation/GetPipeline)).
            - FULL: Include the information from `BASIC`, plus full step
           configuration.
         explode: true
@@ -540,24 +558,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -614,32 +636,40 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -705,8 +735,8 @@ paths:
           The API defaults to the `BASIC` view.
            - BASIC: Include basic information including type, name, version and description
           but not the full step configuration. This is the default value (for both
-          [ListPipelines](/docs/api-reference#operation/ListPipelines) and
-          [GetPipeline](/docs/api-reference#operation/GetPipeline)).
+          [ListPipelines](/api#operation/ListPipelines) and
+          [GetPipeline](/api#operation/GetPipeline)).
            - FULL: Include the information from `BASIC`, plus full step configuration.
         explode: true
         in: query
@@ -745,32 +775,40 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -837,8 +875,8 @@ paths:
           The API defaults to the `BASIC` view.
            - BASIC: Include basic information including type, name, version and description
           but not the full step configuration. This is the default value (for both
-          [ListPipelines](/docs/api-reference#operation/ListPipelines) and
-          [GetPipeline](/docs/api-reference#operation/GetPipeline)).
+          [ListPipelines](/api#operation/ListPipelines) and
+          [GetPipeline](/api#operation/GetPipeline)).
            - FULL: Include the information from `BASIC`, plus full step configuration.
         explode: true
         in: query
@@ -877,17 +915,21 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
@@ -899,17 +941,19 @@ paths:
                     code: 5
                     message: pipeline does not have a default version
               schema:
-                $ref: '#/components/schemas/Status'
+                $ref: '#/components/schemas/Error'
             application/yaml:
               schema:
-                $ref: '#/components/schemas/Status'
+                $ref: '#/components/schemas/Error'
           description: Returned when the pipeline does not have a default version.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -982,24 +1026,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1014,7 +1062,7 @@ paths:
     post:
       description: |-
         The batch version of the
-        [UpsertRecord](/docs/api-reference#operation/UpsertRecord) call.
+        [UpsertRecord](/api#operation/UpsertRecord) call.
       operationId: BatchUpsertRecords
       parameters:
       - description: The collection to upsert the records in, e.g. `my-collection`.
@@ -1041,24 +1089,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1098,24 +1150,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1155,24 +1211,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1237,24 +1297,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1295,12 +1359,12 @@ paths:
         style: form
       - description: |-
           A page token, received from a previous
-          [ListSchemaFields](/docs/api-reference#operation/ListSchemaFields) call.
+          [ListSchemaFields](/api#operation/ListSchemaFields) call.
 
           Provide this to retrieve the subsequent page.
 
           When paginating, all other parameters provided to
-          [ListSchemaFields](/docs/api-reference#operation/ListSchemaFields) must
+          [ListSchemaFields](/api#operation/ListSchemaFields) must
           match the call that provided the page token.
         explode: true
         in: query
@@ -1319,24 +1383,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1376,24 +1444,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1408,7 +1480,7 @@ paths:
     post:
       description: |-
         The batch version of the
-        [CreateSchemaField](/docs/api-reference#operation/CreateSchemaField) call.
+        [CreateSchemaField](/api#operation/CreateSchemaField) call.
       operationId: BatchCreateSchemaFields
       parameters:
       - description: The collection to create the schema fields in, e.g. `my-collection`.
@@ -1435,24 +1507,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1525,32 +1601,40 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
             application/yaml:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1615,24 +1699,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1660,7 +1748,7 @@ paths:
         For more information:
 
         - See [filtering
-        content](https://www.sajari.com/docs/user-guide/integrating-search/filters/)
+        content](https://docs.sajari.com/user-guide/integrating-search/filters/)
         - See [tracking in the Go
         SDK](https://github.com/sajari/sdk-go/blob/v2/session.go)
         - See [tracking in the JS
@@ -1691,24 +1779,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -1761,24 +1853,28 @@ paths:
         "401":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the request does not have valid authentication
             credentials.
         "403":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the user does not have permission to access the
             resource.
         "404":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the resource does not exist.
         "500":
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/Error'
           description: Returned when the API encounters an internal error.
         default:
           content:
@@ -2639,7 +2735,7 @@ components:
             The list of authorized query domains for the collection.
 
             Client-side / browser requests to the
-            [QueryCollection](/docs/api-reference#operation/QueryCollection) call can
+            [QueryCollection](/api#operation/QueryCollection) call can
             be made by any authorized query domain or any of its subdomains. This
             allows your interface to make search requests without having to provide an
             API key in the client-side request.
@@ -2890,8 +2986,8 @@ components:
         The API defaults to the `BASIC` view.
          - BASIC: Include basic information including type, name, version and description
         but not the full step configuration. This is the default value (for both
-        [ListPipelines](/docs/api-reference#operation/ListPipelines) and
-        [GetPipeline](/docs/api-reference#operation/GetPipeline)).
+        [ListPipelines](/api#operation/ListPipelines) and
+        [GetPipeline](/api#operation/GetPipeline)).
          - FULL: Include the information from `BASIC`, plus full step configuration.
       enum:
       - VIEW_UNSPECIFIED
@@ -2905,8 +3001,8 @@ components:
         The API defaults to the `BASIC` view.
          - BASIC: Include basic information including type, name, version and description
         but not the full step configuration. This is the default value (for both
-        [ListPipelines](/docs/api-reference#operation/ListPipelines) and
-        [GetPipeline](/docs/api-reference#operation/GetPipeline)).
+        [ListPipelines](/api#operation/ListPipelines) and
+        [GetPipeline](/api#operation/GetPipeline)).
          - FULL: Include the information from `BASIC`, plus full step configuration.
       enum:
       - VIEW_UNSPECIFIED
@@ -2962,8 +3058,8 @@ components:
         The API defaults to the `BASIC` view.
          - BASIC: Include basic information including type, name, version and description
         but not the full step configuration. This is the default value (for both
-        [ListPipelines](/docs/api-reference#operation/ListPipelines) and
-        [GetPipeline](/docs/api-reference#operation/GetPipeline)).
+        [ListPipelines](/api#operation/ListPipelines) and
+        [GetPipeline](/api#operation/GetPipeline)).
          - FULL: Include the information from `BASIC`, plus full step
         configuration.
       enum:

--- a/internal/openapi/api_collections.go
+++ b/internal/openapi/api_collections.go
@@ -138,7 +138,7 @@ func (a *CollectionsApiService) CreateCollectionExecute(r ApiCreateCollectionReq
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 400 {
-			var v Status
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -148,7 +148,7 @@ func (a *CollectionsApiService) CreateCollectionExecute(r ApiCreateCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -158,7 +158,7 @@ func (a *CollectionsApiService) CreateCollectionExecute(r ApiCreateCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -168,7 +168,7 @@ func (a *CollectionsApiService) CreateCollectionExecute(r ApiCreateCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -178,7 +178,7 @@ func (a *CollectionsApiService) CreateCollectionExecute(r ApiCreateCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 409 {
-			var v Status
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -188,7 +188,7 @@ func (a *CollectionsApiService) CreateCollectionExecute(r ApiCreateCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -311,7 +311,7 @@ func (a *CollectionsApiService) DeleteCollectionExecute(r ApiDeleteCollectionReq
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -321,7 +321,7 @@ func (a *CollectionsApiService) DeleteCollectionExecute(r ApiDeleteCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -331,7 +331,7 @@ func (a *CollectionsApiService) DeleteCollectionExecute(r ApiDeleteCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v Status
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -341,7 +341,7 @@ func (a *CollectionsApiService) DeleteCollectionExecute(r ApiDeleteCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -462,7 +462,7 @@ func (a *CollectionsApiService) GetCollectionExecute(r ApiGetCollectionRequest) 
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -472,7 +472,7 @@ func (a *CollectionsApiService) GetCollectionExecute(r ApiGetCollectionRequest) 
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -482,7 +482,7 @@ func (a *CollectionsApiService) GetCollectionExecute(r ApiGetCollectionRequest) 
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -492,7 +492,7 @@ func (a *CollectionsApiService) GetCollectionExecute(r ApiGetCollectionRequest) 
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -626,7 +626,7 @@ func (a *CollectionsApiService) ListCollectionsExecute(r ApiListCollectionsReque
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -636,7 +636,7 @@ func (a *CollectionsApiService) ListCollectionsExecute(r ApiListCollectionsReque
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -646,7 +646,7 @@ func (a *CollectionsApiService) ListCollectionsExecute(r ApiListCollectionsReque
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -656,7 +656,7 @@ func (a *CollectionsApiService) ListCollectionsExecute(r ApiListCollectionsReque
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -719,7 +719,7 @@ particular string:
 For more information:
 
 - See [filtering
-content](https://www.sajari.com/docs/user-guide/integrating-search/filters/)
+content](https://docs.sajari.com/user-guide/integrating-search/filters/)
 - See [tracking in the Go
 SDK](https://github.com/sajari/sdk-go/blob/v2/session.go)
 - See [tracking in the JS
@@ -806,7 +806,7 @@ func (a *CollectionsApiService) QueryCollectionExecute(r ApiQueryCollectionReque
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -816,7 +816,7 @@ func (a *CollectionsApiService) QueryCollectionExecute(r ApiQueryCollectionReque
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -826,7 +826,7 @@ func (a *CollectionsApiService) QueryCollectionExecute(r ApiQueryCollectionReque
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -836,7 +836,7 @@ func (a *CollectionsApiService) QueryCollectionExecute(r ApiQueryCollectionReque
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -976,7 +976,7 @@ func (a *CollectionsApiService) UpdateCollectionExecute(r ApiUpdateCollectionReq
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -986,7 +986,7 @@ func (a *CollectionsApiService) UpdateCollectionExecute(r ApiUpdateCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -996,7 +996,7 @@ func (a *CollectionsApiService) UpdateCollectionExecute(r ApiUpdateCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v Status
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1006,7 +1006,7 @@ func (a *CollectionsApiService) UpdateCollectionExecute(r ApiUpdateCollectionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()

--- a/internal/openapi/api_pipelines.go
+++ b/internal/openapi/api_pipelines.go
@@ -138,7 +138,7 @@ func (a *PipelinesApiService) CreatePipelineExecute(r ApiCreatePipelineRequest) 
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -148,7 +148,7 @@ func (a *PipelinesApiService) CreatePipelineExecute(r ApiCreatePipelineRequest) 
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -158,7 +158,7 @@ func (a *PipelinesApiService) CreatePipelineExecute(r ApiCreatePipelineRequest) 
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -168,7 +168,7 @@ func (a *PipelinesApiService) CreatePipelineExecute(r ApiCreatePipelineRequest) 
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -309,7 +309,7 @@ func (a *PipelinesApiService) GeneratePipelinesExecute(r ApiGeneratePipelinesReq
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -319,7 +319,7 @@ func (a *PipelinesApiService) GeneratePipelinesExecute(r ApiGeneratePipelinesReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -329,7 +329,7 @@ func (a *PipelinesApiService) GeneratePipelinesExecute(r ApiGeneratePipelinesReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -339,7 +339,7 @@ func (a *PipelinesApiService) GeneratePipelinesExecute(r ApiGeneratePipelinesReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -479,7 +479,7 @@ func (a *PipelinesApiService) GetDefaultPipelineExecute(r ApiGetDefaultPipelineR
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -489,7 +489,7 @@ func (a *PipelinesApiService) GetDefaultPipelineExecute(r ApiGetDefaultPipelineR
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -499,7 +499,7 @@ func (a *PipelinesApiService) GetDefaultPipelineExecute(r ApiGetDefaultPipelineR
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -509,7 +509,7 @@ func (a *PipelinesApiService) GetDefaultPipelineExecute(r ApiGetDefaultPipelineR
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -656,7 +656,7 @@ func (a *PipelinesApiService) GetDefaultVersionExecute(r ApiGetDefaultVersionReq
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -666,7 +666,7 @@ func (a *PipelinesApiService) GetDefaultVersionExecute(r ApiGetDefaultVersionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -676,7 +676,7 @@ func (a *PipelinesApiService) GetDefaultVersionExecute(r ApiGetDefaultVersionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v Status
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -686,7 +686,7 @@ func (a *PipelinesApiService) GetDefaultVersionExecute(r ApiGetDefaultVersionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -831,7 +831,7 @@ func (a *PipelinesApiService) GetPipelineExecute(r ApiGetPipelineRequest) (Pipel
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -841,7 +841,7 @@ func (a *PipelinesApiService) GetPipelineExecute(r ApiGetPipelineRequest) (Pipel
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -851,7 +851,7 @@ func (a *PipelinesApiService) GetPipelineExecute(r ApiGetPipelineRequest) (Pipel
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -861,7 +861,7 @@ func (a *PipelinesApiService) GetPipelineExecute(r ApiGetPipelineRequest) (Pipel
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1007,7 +1007,7 @@ func (a *PipelinesApiService) ListPipelinesExecute(r ApiListPipelinesRequest) (L
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1017,7 +1017,7 @@ func (a *PipelinesApiService) ListPipelinesExecute(r ApiListPipelinesRequest) (L
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1027,7 +1027,7 @@ func (a *PipelinesApiService) ListPipelinesExecute(r ApiListPipelinesRequest) (L
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1037,7 +1037,7 @@ func (a *PipelinesApiService) ListPipelinesExecute(r ApiListPipelinesRequest) (L
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1181,7 +1181,7 @@ func (a *PipelinesApiService) SetDefaultPipelineExecute(r ApiSetDefaultPipelineR
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1191,7 +1191,7 @@ func (a *PipelinesApiService) SetDefaultPipelineExecute(r ApiSetDefaultPipelineR
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1201,7 +1201,7 @@ func (a *PipelinesApiService) SetDefaultPipelineExecute(r ApiSetDefaultPipelineR
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1211,7 +1211,7 @@ func (a *PipelinesApiService) SetDefaultPipelineExecute(r ApiSetDefaultPipelineR
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1357,7 +1357,7 @@ func (a *PipelinesApiService) SetDefaultVersionExecute(r ApiSetDefaultVersionReq
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1367,7 +1367,7 @@ func (a *PipelinesApiService) SetDefaultVersionExecute(r ApiSetDefaultVersionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1377,7 +1377,7 @@ func (a *PipelinesApiService) SetDefaultVersionExecute(r ApiSetDefaultVersionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -1387,7 +1387,7 @@ func (a *PipelinesApiService) SetDefaultVersionExecute(r ApiSetDefaultVersionReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()

--- a/internal/openapi/api_records.go
+++ b/internal/openapi/api_records.go
@@ -46,7 +46,7 @@ func (r ApiBatchUpsertRecordsRequest) Execute() (BatchUpsertRecordsResponse, *_n
 /*
  * BatchUpsertRecords Batch upsert records
  * The batch version of the
-[UpsertRecord](/docs/api-reference#operation/UpsertRecord) call.
+[UpsertRecord](/api#operation/UpsertRecord) call.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param collectionId The collection to upsert the records in, e.g. `my-collection`.
  * @return ApiBatchUpsertRecordsRequest
@@ -129,7 +129,7 @@ func (a *RecordsApiService) BatchUpsertRecordsExecute(r ApiBatchUpsertRecordsReq
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -139,7 +139,7 @@ func (a *RecordsApiService) BatchUpsertRecordsExecute(r ApiBatchUpsertRecordsReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -149,7 +149,7 @@ func (a *RecordsApiService) BatchUpsertRecordsExecute(r ApiBatchUpsertRecordsReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -159,7 +159,7 @@ func (a *RecordsApiService) BatchUpsertRecordsExecute(r ApiBatchUpsertRecordsReq
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -291,7 +291,7 @@ func (a *RecordsApiService) DeleteRecordExecute(r ApiDeleteRecordRequest) (inter
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -301,7 +301,7 @@ func (a *RecordsApiService) DeleteRecordExecute(r ApiDeleteRecordRequest) (inter
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -311,7 +311,7 @@ func (a *RecordsApiService) DeleteRecordExecute(r ApiDeleteRecordRequest) (inter
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -321,7 +321,7 @@ func (a *RecordsApiService) DeleteRecordExecute(r ApiDeleteRecordRequest) (inter
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -453,7 +453,7 @@ func (a *RecordsApiService) GetRecordExecute(r ApiGetRecordRequest) (map[string]
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -463,7 +463,7 @@ func (a *RecordsApiService) GetRecordExecute(r ApiGetRecordRequest) (map[string]
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -473,7 +473,7 @@ func (a *RecordsApiService) GetRecordExecute(r ApiGetRecordRequest) (map[string]
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -483,7 +483,7 @@ func (a *RecordsApiService) GetRecordExecute(r ApiGetRecordRequest) (map[string]
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -639,7 +639,7 @@ func (a *RecordsApiService) UpsertRecordExecute(r ApiUpsertRecordRequest) (Upser
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -649,7 +649,7 @@ func (a *RecordsApiService) UpsertRecordExecute(r ApiUpsertRecordRequest) (Upser
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -659,7 +659,7 @@ func (a *RecordsApiService) UpsertRecordExecute(r ApiUpsertRecordRequest) (Upser
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -669,7 +669,7 @@ func (a *RecordsApiService) UpsertRecordExecute(r ApiUpsertRecordRequest) (Upser
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()

--- a/internal/openapi/api_schema.go
+++ b/internal/openapi/api_schema.go
@@ -46,7 +46,7 @@ func (r ApiBatchCreateSchemaFieldsRequest) Execute() (BatchCreateSchemaFieldsRes
 /*
  * BatchCreateSchemaFields Batch create schema fields
  * The batch version of the
-[CreateSchemaField](/docs/api-reference#operation/CreateSchemaField) call.
+[CreateSchemaField](/api#operation/CreateSchemaField) call.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param collectionId The collection to create the schema fields in, e.g. `my-collection`.
  * @return ApiBatchCreateSchemaFieldsRequest
@@ -129,7 +129,7 @@ func (a *SchemaApiService) BatchCreateSchemaFieldsExecute(r ApiBatchCreateSchema
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -139,7 +139,7 @@ func (a *SchemaApiService) BatchCreateSchemaFieldsExecute(r ApiBatchCreateSchema
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -149,7 +149,7 @@ func (a *SchemaApiService) BatchCreateSchemaFieldsExecute(r ApiBatchCreateSchema
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -159,7 +159,7 @@ func (a *SchemaApiService) BatchCreateSchemaFieldsExecute(r ApiBatchCreateSchema
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -291,7 +291,7 @@ func (a *SchemaApiService) CreateSchemaFieldExecute(r ApiCreateSchemaFieldReques
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -301,7 +301,7 @@ func (a *SchemaApiService) CreateSchemaFieldExecute(r ApiCreateSchemaFieldReques
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -311,7 +311,7 @@ func (a *SchemaApiService) CreateSchemaFieldExecute(r ApiCreateSchemaFieldReques
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -321,7 +321,7 @@ func (a *SchemaApiService) CreateSchemaFieldExecute(r ApiCreateSchemaFieldReques
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -459,7 +459,7 @@ func (a *SchemaApiService) ListSchemaFieldsExecute(r ApiListSchemaFieldsRequest)
 			error: localVarHTTPResponse.Status,
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -469,7 +469,7 @@ func (a *SchemaApiService) ListSchemaFieldsExecute(r ApiListSchemaFieldsRequest)
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -479,7 +479,7 @@ func (a *SchemaApiService) ListSchemaFieldsExecute(r ApiListSchemaFieldsRequest)
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
@@ -489,7 +489,7 @@ func (a *SchemaApiService) ListSchemaFieldsExecute(r ApiListSchemaFieldsRequest)
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
-			var v interface{}
+			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()

--- a/internal/openapi/model_collection.go
+++ b/internal/openapi/model_collection.go
@@ -26,7 +26,7 @@ type Collection struct {
 	CreateTime *time.Time `json:"create_time,omitempty"`
 	// The collection's display name. You can change this at any time.
 	DisplayName string `json:"display_name"`
-	// The list of authorized query domains for the collection.  Client-side / browser requests to the [QueryCollection](/docs/api-reference#operation/QueryCollection) call can be made by any authorized query domain or any of its subdomains. This allows your interface to make search requests without having to provide an API key in the client-side request.
+	// The list of authorized query domains for the collection.  Client-side / browser requests to the [QueryCollection](/api#operation/QueryCollection) call can be made by any authorized query domain or any of its subdomains. This allows your interface to make search requests without having to provide an API key in the client-side request.
 	AuthorizedQueryDomains *[]string `json:"authorized_query_domains,omitempty"`
 }
 

--- a/internal/openapi/model_get_default_version_request_view.go
+++ b/internal/openapi/model_get_default_version_request_view.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 )
 
-// GetDefaultVersionRequestView  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
+// GetDefaultVersionRequestView  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
 type GetDefaultVersionRequestView string
 
 // List of GetDefaultVersionRequestView

--- a/internal/openapi/model_get_pipeline_request_view.go
+++ b/internal/openapi/model_get_pipeline_request_view.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 )
 
-// GetPipelineRequestView  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
+// GetPipelineRequestView  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
 type GetPipelineRequestView string
 
 // List of GetPipelineRequestView

--- a/internal/openapi/model_list_pipelines_request_view.go
+++ b/internal/openapi/model_list_pipelines_request_view.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 )
 
-// ListPipelinesRequestView  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/docs/api-reference#operation/ListPipelines) and [GetPipeline](/docs/api-reference#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
+// ListPipelinesRequestView  - VIEW_UNSPECIFIED: The default / unset value. The API defaults to the `BASIC` view.  - BASIC: Include basic information including type, name, version and description but not the full step configuration. This is the default value (for both [ListPipelines](/api#operation/ListPipelines) and [GetPipeline](/api#operation/GetPipeline)).  - FULL: Include the information from `BASIC`, plus full step configuration.
 type ListPipelinesRequestView string
 
 // List of ListPipelinesRequestView


### PR DESCRIPTION
Previously the OpenAPI spec left the error response types out which
meant that they ended up as `interface{}` in the generated Go code.

Now, they are of type `Error`.