### PR TITLE
key: don't use %q in key String method

### DIFF
--- a/record.go
+++ b/record.go
@@ -37,8 +37,8 @@ type Key struct {
 	value interface{}
 }
 
-// NewKey creates a new Key with a field and value.  Field must be marked as unique in
-// the collection schema.
+// NewKey creates a new key with a field and value. Field must be marked as
+// unique in the collection schema.
 func NewKey(field string, value interface{}) *Key {
 	return &Key{
 		field: field,
@@ -46,12 +46,18 @@ func NewKey(field string, value interface{}) *Key {
 	}
 }
 
+// Field returns the key's field.
+func (k *Key) Field() string { return k.field }
+
+// Value returns the key's value.
+func (k *Key) Value() interface{} { return k.value }
+
 // String implements Stringer.
 func (k *Key) String() string {
 	if k == nil {
 		return ""
 	}
-	return fmt.Sprintf("Key{Field: %q, Value: %q}", k.field, k.value)
+	return fmt.Sprintf("Key{Field: %v, Value: %v}", k.field, k.value)
 }
 
 type keys []*Key

--- a/record_test.go
+++ b/record_test.go
@@ -20,3 +20,21 @@ func TestKeyIterator_Next_Done(t *testing.T) {
 		t.Errorf("Next() error = %v, want wrapped ErrDone", err)
 	}
 }
+
+func TestKey_String(t *testing.T) {
+	tests := []struct {
+		key  *Key
+		want string
+	}{
+		{NewKey("id", 1234), "Key{Field: id, Value: 1234}"},
+		{NewKey("id", "1234"), "Key{Field: id, Value: 1234}"},
+		{NewKey("url", "https://example.com"), "Key{Field: url, Value: https://example.com}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.key.String(); got != tt.want {
+				t.Errorf("Key.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The verb %q on an interface{} does not really print anything useful, see
[1] which prints '�' for the int 12345678.

[1]: https://go.dev/play/p/_RqPBXyRjIc